### PR TITLE
nix-prefetch-docker: handle overrides correctly

### DIFF
--- a/pkgs/build-support/docker/nix-prefetch-docker
+++ b/pkgs/build-support/docker/nix-prefetch-docker
@@ -38,7 +38,7 @@ get_image_digest(){
         imageTag="latest"
     fi
 
-    skopeo inspect "docker://$imageName:$imageTag" | jq '.Digest' -r
+    skopeo --override-os ${os} --override-arch ${arch} inspect "docker://$imageName:$imageTag" | jq '.Digest' -r
 }
 
 get_name() {


### PR DESCRIPTION
Without this change, the `--os` and `--arch` switches are disregarded
for operations involving `skopeo inspect` invocations. This means that,
for example, one cannot fetch Linux images while on macOS.
